### PR TITLE
QPD-378 #comment Update for Django Extras graphene

### DIFF
--- a/_version.py
+++ b/_version.py
@@ -1,4 +1,4 @@
 """
 Specifies the version
 """
-__version__ = '1.1.dev5740'
+__version__ = '1.0.dev306'

--- a/graphene_django_extras/fields.py
+++ b/graphene_django_extras/fields.py
@@ -25,7 +25,7 @@ from .utils import get_extra_filters, queryset_factory, get_related_fields, find
 class DjangoObjectField(Field):
     def __init__(self, _type, *args, **kwargs):
         kwargs["id"] = ID(
-            required=True, description="Django object unique identification field"
+                required=True, description="Django object unique identification field"
         )
 
         super(DjangoObjectField, self).__init__(_type, *args, **kwargs)
@@ -60,13 +60,13 @@ class DjangoListField(DLF):
 
 class DjangoFilterListField(Field):
     def __init__(
-        self,
-        _type,
-        fields=None,
-        extra_filter_meta=None,
-        filterset_class=None,
-        *args,
-        **kwargs,
+            self,
+            _type,
+            fields=None,
+            extra_filter_meta=None,
+            filterset_class=None,
+            *args,
+            **kwargs,
     ):
 
         if DJANGO_FILTER_INSTALLED:
@@ -80,25 +80,25 @@ class DjangoFilterListField(Field):
             filterset_class = filterset_class or _type._meta.filterset_class
             self.filterset_class = get_filterset_class(filterset_class, **meta)
             self.filtering_args = get_filtering_args_from_filterset(
-                self.filterset_class, _type
+                    self.filterset_class, _type
             )
             kwargs.setdefault("args", {})
             kwargs["args"].update(self.filtering_args)
 
             if "id" not in kwargs["args"].keys():
                 self.filtering_args.update(
-                    {
-                        "id": Argument(
-                            ID, description="Django object unique identification field"
-                        )
-                    }
+                        {
+                            "id": Argument(
+                                    ID, description="Django object unique identification field"
+                            )
+                        }
                 )
                 kwargs["args"].update(
-                    {
-                        "id": Argument(
-                            ID, description="Django object unique identification field"
-                        )
-                    }
+                        {
+                            "id": Argument(
+                                    ID, description="Django object unique identification field"
+                            )
+                        }
                 )
 
         if not kwargs.get("description", None):
@@ -124,15 +124,15 @@ class DjangoFilterListField(Field):
             try:
                 if filter_kwargs:
                     qs = operator.attrgetter(
-                        "{}.filter".format(
-                            getattr(field, "related_name", None) or field.name
-                        )
+                            "{}.filter".format(
+                                    getattr(field, "related_name", None) or field.name
+                            )
                     )(root)(**filter_kwargs)
                 else:
                     qs = operator.attrgetter(
-                        "{}.all".format(
-                            getattr(field, "related_name", None) or field.name
-                        )
+                            "{}.all".format(
+                                    getattr(field, "related_name", None) or field.name
+                            )
                     )(root)()
             except AttributeError:
                 qs = None
@@ -140,7 +140,7 @@ class DjangoFilterListField(Field):
         if qs is None:
             qs = queryset_factory(manager, info.field_nodes, info.fragments, **kwargs)
             qs = filterset_class(
-                data=filter_kwargs, queryset=qs, request=info.context
+                    data=filter_kwargs, queryset=qs, request=info.context
             ).qs
 
             if root and is_valid_django_model(root._meta.model):
@@ -154,25 +154,25 @@ class DjangoFilterListField(Field):
         while isinstance(current_type, Structure):
             current_type = current_type.of_type
         return partial(
-            self.list_resolver,
-            current_type._meta.model._default_manager,
-            self.filterset_class,
-            self.filtering_args,
+                self.list_resolver,
+                current_type._meta.model._default_manager,
+                self.filterset_class,
+                self.filtering_args,
         )
 
 
 class DjangoFilterPaginateListField(Field):
     def __init__(
-        self,
-        _type,
-        pagination=None,
-        fields=None,
-        extra_filter_meta=None,
-        filterset_class=None,
-        *args,
-        **kwargs,
+            self,
+            _type,
+            pagination=None,
+            fields=None,
+            extra_filter_meta=None,
+            filterset_class=None,
+            *args,
+            **kwargs,
     ):
-
+        self.resolve_func = kwargs['resolve_queryset']
         _fields = _type._meta.filter_fields
         _model = _type._meta.model
 
@@ -184,25 +184,26 @@ class DjangoFilterPaginateListField(Field):
         filterset_class = filterset_class or _type._meta.filterset_class
         self.filterset_class = get_filterset_class(filterset_class, **meta)
         self.filtering_args = get_filtering_args_from_filterset(
-            self.filterset_class, _type
+                self.filterset_class, _type
         )
         kwargs.setdefault("args", {})
         kwargs["args"].update(self.filtering_args)
 
+
         if "id" not in kwargs["args"].keys():
             self.filtering_args.update(
-                {
-                    "id": Argument(
-                        ID, description="Django object unique identification field"
-                    )
-                }
+                    {
+                        "id": Argument(
+                                ID, description="Django object unique identification field"
+                        )
+                    }
             )
             kwargs["args"].update(
-                {
-                    "id": Argument(
-                        ID, description="Django object unique identification field"
-                    )
-                }
+                    {
+                        "id": Argument(
+                                ID, description="Django object unique identification field"
+                        )
+                    }
             )
 
         pagination = pagination or graphql_api_settings.DEFAULT_PAGINATION_CLASS()
@@ -220,22 +221,25 @@ class DjangoFilterPaginateListField(Field):
         if not kwargs.get("description", None):
             kwargs["description"] = "{} list".format(_type._meta.model.__name__)
 
+        kwargs.pop('resolve_queryset')
+
         super(DjangoFilterPaginateListField, self).__init__(
-            List(NonNull(_type)), *args, **kwargs
+                List(NonNull(_type)), *args, **kwargs
         )
 
     @property
     def model(self):
         return self.type.of_type._meta.node._meta.model
 
-    def get_queryset(self, manager, info, **kwargs):
-        return queryset_factory(manager, info.field_nodes, info.fragments, info, **kwargs)
+    def get_queryset(self, manager, info, resolve_func, **kwargs):
+        return queryset_factory(manager, info.field_nodes, info.fragments, info, resolve_func, **kwargs)
 
     def list_resolver(
-        self, manager, filterset_class, filtering_args, root, info, **kwargs
+            self, manager, filterset_class, filtering_args, root, info, **kwargs
     ):
+        # print()
         filter_kwargs = {k: v for k, v in kwargs.items() if k in filtering_args}
-        qs = self.get_queryset(manager, info, **kwargs)
+        qs = self.get_queryset(manager, info, resolve_func=self.resolve_func, **kwargs)
         qs = filterset_class(data=filter_kwargs, queryset=qs, request=info.context).qs
 
         if root and is_valid_django_model(root._meta.model):
@@ -252,22 +256,22 @@ class DjangoFilterPaginateListField(Field):
         while isinstance(current_type, Structure):
             current_type = current_type.of_type
         return partial(
-            self.list_resolver,
-            current_type._meta.model._default_manager,
-            self.filterset_class,
-            self.filtering_args,
+                self.list_resolver,
+                current_type._meta.model._default_manager,
+                self.filterset_class,
+                self.filtering_args,
         )
 
 
 class DjangoListObjectField(Field):
     def __init__(
-        self,
-        _type,
-        fields=None,
-        extra_filter_meta=None,
-        filterset_class=None,
-        *args,
-        **kwargs,
+            self,
+            _type,
+            fields=None,
+            extra_filter_meta=None,
+            filterset_class=None,
+            *args,
+            **kwargs,
     ):
 
         if DJANGO_FILTER_INSTALLED:
@@ -283,7 +287,7 @@ class DjangoListObjectField(Field):
             filterset_class = filterset_class or _type._meta.filterset_class
             self.filterset_class = get_filterset_class(filterset_class, **meta)
             self.filtering_args = get_filtering_args_from_filterset(
-                self.filterset_class, _type
+                    self.filterset_class, _type
             )
             kwargs.setdefault("args", {})
             kwargs["args"].update(self.filtering_args)
@@ -291,7 +295,7 @@ class DjangoListObjectField(Field):
             if "id" not in kwargs["args"].keys():
                 id_description = "Django object unique identification field"
                 self.filtering_args.update(
-                    {"id": Argument(ID, description=id_description)}
+                        {"id": Argument(ID, description=id_description)}
                 )
                 kwargs["args"].update({"id": Argument(ID, description=id_description)})
 
@@ -305,9 +309,8 @@ class DjangoListObjectField(Field):
         return self.type._meta.model
 
     def list_resolver(
-        self, manager, filterset_class, filtering_args, root, info, **kwargs
+            self, manager, filterset_class, filtering_args, root, info, **kwargs
     ):
-
         qs = queryset_factory(manager, info.field_nodes, info.fragments, **kwargs)
 
         filter_kwargs = {k: v for k, v in kwargs.items() if k in filtering_args}
@@ -316,15 +319,15 @@ class DjangoListObjectField(Field):
         count = qs.count()
 
         return DjangoListObjectBase(
-            count=count,
-            results=maybe_queryset(qs),
-            results_field_name=self.type._meta.results_field_name,
+                count=count,
+                results=maybe_queryset(qs),
+                results_field_name=self.type._meta.results_field_name,
         )
 
     def wrap_resolve(self, parent_resolver):
         return partial(
-            self.list_resolver,
-            self.type._meta.model._default_manager,
-            self.filterset_class,
-            self.filtering_args,
+                self.list_resolver,
+                self.type._meta.model._default_manager,
+                self.filterset_class,
+                self.filtering_args,
         )

--- a/graphene_django_extras/utils.py
+++ b/graphene_django_extras/utils.py
@@ -245,14 +245,9 @@ def _get_queryset(klass, info=None, resolve_queryset=None, **kwargs):
     #         "Manager, or QuerySet".format(klass__name)
     #     )
     if manager:
-        print(f'test={resolve_queryset}')
-        print(f'type={type(resolve_queryset)}')
         value = resolve_queryset["func_name"]
-        print(f'svfv = { value }')
-        print('1234567890-')
         if hasattr(manager.model, resolve_queryset['func_name']):
             _method = getattr(manager.model, resolve_queryset['func_name'])(info.context.user, kwargs)
-            print(_method)
             return _method
         else:
             raise ValueError(
@@ -263,8 +258,6 @@ def _get_queryset(klass, info=None, resolve_queryset=None, **kwargs):
         raise ValueError(
                 f"No manager for class = {klass}"
         )
-    # return manager.all()
-
 
 def get_Object_or_None(klass, *args, **kwargs):
     """

--- a/graphene_django_extras/utils.py
+++ b/graphene_django_extras/utils.py
@@ -96,9 +96,7 @@ def get_model_fields(model):
         (field.name, field) for field in all_fields_list if field not in exclude_fields
     ]
 
-    all_fields = local_fields + reverse_fields
-
-    return all_fields
+    return local_fields + reverse_fields
 
 
 def get_obj(app_label, model_name, object_id):
@@ -115,8 +113,7 @@ def get_obj(app_label, model_name, object_id):
                 app_label, model_name
         )
 
-        obj = get_Object_or_None(model, pk=object_id)
-        return obj
+        return get_Object_or_None(model, pk=object_id)
 
     except model.DoesNotExist:
         return None
@@ -307,11 +304,10 @@ def get_related_fields(model):
 
 
 def find_field(field, fields_dict):
-    temp = fields_dict.get(
-            field.name.value, fields_dict.get(to_snake_case(field.name.value), None)
+    return fields_dict.get(
+        field.name.value,
+        fields_dict.get(to_snake_case(field.name.value), None),
     )
-
-    return temp
 
 
 def recursive_params(
@@ -404,7 +400,7 @@ def queryset_factory(manager, fields_asts=None, fragments=None, info=None, resol
     elif not select_related and prefetch_related:
         # return _get_queryset(manager.prefetch_related(*prefetch_related))
         return result.prefetch_related(*prefetch_related)
-    elif select_related and not prefetch_related:
+    elif select_related:
         # return _get_queryset(manager.select_related(*select_related))
         return result.select_related(*select_related)
     return result

--- a/graphene_django_extras/utils.py
+++ b/graphene_django_extras/utils.py
@@ -221,7 +221,7 @@ def is_required(field):
     return not blank and default == NOT_PROVIDED
 
 
-def _get_queryset(klass, info=None, **kwargs):
+def _get_queryset(klass, info=None, resolve_queryset=None, **kwargs):
     """
     Returns a QuerySet from a Model, Manager, or QuerySet. Created to make
     get_object_or_404 and get_list_or_404 more DRY.
@@ -245,8 +245,15 @@ def _get_queryset(klass, info=None, **kwargs):
     #         "Manager, or QuerySet".format(klass__name)
     #     )
     if manager:
-        if hasattr(manager.model, 'resolve_queryset'):
-            return manager.model.resolve_queryset(info.context.user, kwargs)
+        print(f'test={resolve_queryset}')
+        print(f'type={type(resolve_queryset)}')
+        value = resolve_queryset["func_name"]
+        print(f'svfv = { value }')
+        print('1234567890-')
+        if hasattr(manager.model, resolve_queryset['func_name']):
+            _method = getattr(manager.model, resolve_queryset['func_name'])(info.context.user, kwargs)
+            print(_method)
+            return _method
         else:
             raise ValueError(
                     f"Model does not contain resolve queryset method, class = {klass} "
@@ -361,7 +368,7 @@ def recursive_params(
     return select_related, prefetch_related
 
 
-def queryset_factory(manager, fields_asts=None, fragments=None, info=None, **kwargs):
+def queryset_factory(manager, fields_asts=None, fragments=None, info=None, resolve_func=None, **kwargs):
 
     select_related = set()
     prefetch_related = set()
@@ -387,7 +394,7 @@ def queryset_factory(manager, fields_asts=None, fragments=None, info=None, **kwa
                 prefetch_related,
         )
 
-    result = _get_queryset(manager, info, **kwargs)
+    result = _get_queryset(manager, info, resolve_func, **kwargs)
 
     if select_related and prefetch_related:
 

--- a/graphene_django_extras/utils.py
+++ b/graphene_django_extras/utils.py
@@ -243,9 +243,8 @@ def _get_queryset(klass, info=None, resolve_queryset=None, **kwargs):
     #     )
     if manager:
         value = resolve_queryset["func_name"]
-        if hasattr(manager.model, resolve_queryset['func_name']):
-            _method = getattr(manager.model, resolve_queryset['func_name'])(info.context.user, kwargs)
-            return _method
+        if hasattr(manager.model, value):
+            return getattr(manager.model, value)(info.context.user, kwargs)
         else:
             raise ValueError(
                     f"Model does not contain resolve queryset method, class = {klass} "


### PR DESCRIPTION
- [X] Added a param in the function that can accept the model method name such that it will be configured from the meta program and could name the method any valid semantic name. Would be helpful if there are more than one api_schema defined in the model and if one or both of them are using a custom _get_query_ method to call and handle querysets.