### PR TITLE
QPD-315: Passing context to queryset instead of only passing user

### DIFF
--- a/_version.py
+++ b/_version.py
@@ -1,4 +1,4 @@
 """
 Specifies the version
 """
-__version__ = '1.0.dev315'
+__version__ = '1.1.dev315'

--- a/graphene_django_extras/utils.py
+++ b/graphene_django_extras/utils.py
@@ -240,7 +240,7 @@ def _get_queryset(klass, info=None,resolve_queryset=None, **kwargs):
         return manager if isinstance(klass, QuerySet) else manager.all()
     else:
         if manager:
-            return getattr(manager.model, resolve_queryset['func_name'], None)(manager.model,info.context.user, kwargs)
+            return getattr(manager.model, resolve_queryset['func_name'], None)(manager.model,info.context, kwargs)
 
 
 def get_Object_or_None(klass,info=None,type=None, *args, **kwargs):


### PR DESCRIPTION
Passing the context instead of user as in the default queryset signature context is been accepted instead of direct user.The signature test case was failing.